### PR TITLE
fix: Remove enviroment projects from openshift

### DIFF
--- a/setup-rhmap.sh
+++ b/setup-rhmap.sh
@@ -68,6 +68,7 @@ then
     echo "Deleting existing projects"
     oc delete project rhmap-core > /dev/null 2>&1
     oc delete project rhmap-1-node-mbaas > /dev/null 2>&1
+    oc delete project $(oc projects | grep 'RHMAP Environment' | awk '{print $1}') > /dev/null 2>&1
     echo "Waiting for OpenShift to remove projects"
     i=100
     for num in $(seq 1 ${i})


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-20847

# What
Add functionality to remove an environment project from minishift

# Why
The clean flag **-c** doesn't remove environment projects

# How
grep for `RHMAP Environment` on `oc projects` and pass to `oc delete projects`

# Verification Steps
```
➜  minishift-install-rhmap git:(delete-enviroments) oc delete project $(oc projects | grep 'RHMAP Environment' | awk '{print $1}')
project "rhmap-may-the-fourth-be-with-you-dev" deleted
project "rhmap-may-the-fourth-be-with-you-live" deleted
```


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 