### PR TITLE
Fix link for fh-openshift-templates repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 The script does the following
 - Logs into Docker
 - Logs onto Minishift with oc
-- Prompts used for IP address for minishift
+- Prompts user for IP address for minishift
 - Creates a inventory file (minishift-example) with the IP address in your home drive to be used with the Ansible installer
 - Adds a docker secret to all new projects
 - Deletes existing rhmap projects when used with -c flag
@@ -25,7 +25,7 @@ The script does the following
 - [Minishift installed](https://github.com/fheng/help/blob/master/new_hires/new_hire_chapter_2.2.md#install-minishift-locally)
 - The following repos cloned to your home/work directory
   - [fh-core-openshift-templates](https://github.com/fheng/fh-core-openshift-templates)
-  - [fh-openshift-templates](https://github.com/fheng/fh-openshift-templates)
+  - [fh-openshift-templates](https://github.com/feedhenry/fh-openshift-templates)
   - [rhmap-ansible](https://github.com/fheng/rhmap-ansible)
 
 ## Usage


### PR DESCRIPTION
# Jira link(s)

n/a

# What

While setting up my local environment for the 4.x delivery team, @davidffrench pointed us to this repo for how to simply our dev/testing with minishift.  In doing so, I noticed the link for the fh-openshift-templates repo was pointing to the old location under the internal-only fheng organisation.  It should be pointing to the new location under the publicly accessible feedhenry organisation.

# Why

n/a

# How

n/a

# Verification Steps

n/a

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 