### PR TITLE
feat: Added in a start of minishift and automatically aquire the ip address

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 The script does the following
 - Logs into Docker
+- Starts Minishift with the required resources 
 - Logs onto Minishift with oc
-- Prompts user for IP address for minishift
 - Creates a inventory file (minishift-example) with the IP address in your home drive to be used with the Ansible installer
 - Adds a docker secret to all new projects
 - Deletes existing rhmap projects when used with -c flag

--- a/setup-rhmap.sh
+++ b/setup-rhmap.sh
@@ -28,9 +28,9 @@ printf "\rProgress : [${done// /#}${undone// /-}] ${precentage}%%"
 # login to docker
 docker login
 
-echo Enter your minishift ip only e.g. 192.168.64.4:
-read IP
-echo " "
+# Start minishift and find address
+minishift start --memory="10GB" --disk-size="69GB" --cpus=6
+IP=$(minishift ip)
 echo $IP
 echo " "
 echo "IP address set in inventory file"


### PR DESCRIPTION
# What
Add a minishift start and auto find the ip address for minishift


# Why
users can start minishift with the incorrect resources , and auto finding the ip address removes  a manual step



# How
made changes to the setup-rhmap.sh file


# Verification Steps
Run the script ./setup-rhmap.sh
Should proceed with minishift start 
Shouldn't require users to enter the ip address
Should complete as normal 


## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 