### PR TITLE
feat: add minishift profile creation

### DIFF
--- a/setup-rhmap.sh
+++ b/setup-rhmap.sh
@@ -28,7 +28,8 @@ printf "\rProgress : [${done// /#}${undone// /-}] ${precentage}%%"
 # login to docker
 docker login
 
-# Start minishift and find address
+# Create profile start minishift and find address
+minishift profile set rhmap-4x
 minishift start --memory="10GB" --disk-size="69GB" --cpus=6
 IP=$(minishift ip)
 echo $IP


### PR DESCRIPTION
# What
Add a line to create a profile rhmap-4x

# Why
need a fresh profile in order to set a env for cpu and disk space 



# How
updated the setup-rhmap.sh


# Verification Steps
- Run the script ./setup-rhmap.sh
- Should proceed with minishift start
- Should complete as normal


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 