### PR TITLE
fix: Fix typo in oc cluster up command

### DIFF
--- a/setup-rhmap.sh
+++ b/setup-rhmap.sh
@@ -46,7 +46,7 @@ docker login
 if [[ $1 = "-oc" ]] || [[ $2 = "-oc" ]]   
 then
     IP=127.0.0.1
-    oc cluster up --use-existing-config=true --host-data-dir=$HOMEg/vm/data
+    oc cluster up --use-existing-config=true --host-data-dir=$HOME/vm/data
 else 
     minishift profile set rhmap-4x
     minishift start --memory="10GB" --disk-size="69GB" --cpus=6


### PR DESCRIPTION
# Jira link(s)
None


# What
Fix typo in oc cluster up command


# Why
Command will not work as expected



# How
Change --host-data-dir=$HOMEg/vm/data to --host-data-dir=$HOME/vm/data


# Verification Steps
None


## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 