### PR TITLE
fix: Update nodejs image streams

### DIFF
--- a/setup-rhmap.sh
+++ b/setup-rhmap.sh
@@ -129,6 +129,7 @@ git pull upstream "$branch"
 
 
 # ansible installer for rhmap
+sudo ansible-playbook -i ~/minishift-example --tags=image_stream -e kubeconfig=~/.kube/config playbooks/poc.yml
 sudo ansible-playbook -i ~/minishift-example --tags=deploy -e strict_mode=false -e core_templates_dir=~/work/fh-core-openshift-templates/generated -e mbaas_templates_dir=~/work/fh-openshift-templates -e mbaas_target_id=test playbooks/poc.yml
 
 


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-21527


# What
nodejs image streams are not getting updated in OpenShift. So the node 10 image stream does not exist.


# Why
When specifying the `--tags` argument in an ansible command, it will only run tasks with the specified tag. We are only specifying the `deploy` tag previously. 



# How
Run a separate command specifying `--tags=image_stream` to update the image streams in OpenShift.


# Verification Steps
1. run `oc get is nodejs -o json -n openshift` and you will see that there is no node10 image stream available.
2. run this script `./setup-rhmap.sh`
3. run `oc get is nodejs -o json -n openshift` and you will see that there is now a node10 image stream available.


## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 