### PR TITLE
fix: add clsuter admin role to developer

### DIFF
--- a/setup-rhmap.sh
+++ b/setup-rhmap.sh
@@ -73,6 +73,7 @@ fi
 
 # # setting the docker pull secret for any new pod
 oc login https://$IP:8443 -u developer -p developer
+oc adm policy --as system:admin add-cluster-role-to-user cluster-admin developer
 
 # kill and remove existing observe process
 kill $(ps aux | grep '[o]c_observe_dev' | awk '{print $2}')


### PR DESCRIPTION
# Jira link(s)
None


# What
Add cluster admin role to the developer user


# Why
Unable to add image streams to openshift namespace as developer because it doesn't have access



# How
`oc adm policy --as system:admin add-cluster-role-to-user cluster-admin developer`


# Verification Steps
1. Run this script


## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 