### PR TITLE
fix: change the default domain name in the inventory file: RHMAP-21792

### DIFF
--- a/minishift-example
+++ b/minishift-example
@@ -6,7 +6,7 @@ mbaas
 [Nodes:vars]
 ansible_connection=local
 target="cluster_up"
-domain_name="my-domain"
+domain_name="rhmap-core"
 git_external_protocol=http
 mbaas_target_id=test
 skip_tls=true


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-21792


# What
change the domain name in the inventory file


# Why
poc playbook creates a url for login of the form 
```
https://rhmap-core.192.168.42.20.nip.io/box/srv/1.1/act/sys/auth/login
```
but if the value is unchanged the actual url will be 
```
https://my-domain.192.168.42.20.nip.io/box/srv/1.1/act/sys/auth/login
```



# How
changed the inventory file


# Verification Steps
run the ./setup-rhmap.sh script


## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 